### PR TITLE
Fetch odata metadata from azure url

### DIFF
--- a/cmd/odata.go
+++ b/cmd/odata.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+
+	"github.com/mgtv-tech/redis-GunYu/config"
+	"github.com/mgtv-tech/redis-GunYu/pkg/log"
+	"github.com/mgtv-tech/redis-GunYu/pkg/odata"
+)
+
+// ODataCmd represents the OData metadata command
+type ODataCmd struct {
+	baseURL string
+}
+
+// NewODataCmd creates a new OData command
+func NewODataCmd() *ODataCmd {
+	return &ODataCmd{}
+}
+
+// Name returns the command name
+func (c *ODataCmd) Name() string {
+	return "odata"
+}
+
+// Run executes the OData metadata fetching command
+func (c *ODataCmd) Run() error {
+	// Get the OData URL from configuration or environment
+	flags := config.GetFlag()
+	odataURL := flags.ODataCmd.URL
+	if odataURL == "" {
+		odataURL = os.Getenv("ODATA_URL")
+	}
+	if odataURL == "" {
+		return fmt.Errorf("OData URL not provided. Use -odata.url flag, set ODATA_URL environment variable, or provide as argument")
+	}
+
+	log.Infof("Fetching OData metadata from: %s", odataURL)
+
+	client := odata.NewClient(odataURL)
+	
+	// Set authentication if provided
+	if flags.ODataCmd.Token != "" {
+		client.SetAuthToken(flags.ODataCmd.Token)
+		log.Infof("Using OAuth token for authentication")
+	} else if flags.ODataCmd.APIKey != "" {
+		client.SetAPIKey(flags.ODataCmd.APIKey)
+		log.Infof("Using API key for authentication")
+	}
+	
+	metadata, err := client.FetchMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to fetch OData metadata: %w", err)
+	}
+
+	log.Infof("Successfully fetched OData metadata")
+	log.Infof("Found %d data services", len(metadata.DataServices))
+	
+	// Determine output destination
+	output := flags.ODataCmd.Output
+	if output == "" {
+		output = "stdout"
+	}
+	
+	// Format and output the metadata
+	format := flags.ODataCmd.Format
+	if err := c.outputMetadata(metadata, format, output); err != nil {
+		return fmt.Errorf("failed to output metadata: %w", err)
+	}
+
+	return nil
+}
+
+// outputMetadata outputs the metadata in the specified format
+func (c *ODataCmd) outputMetadata(metadata *odata.Metadata, format, output string) error {
+	var data []byte
+	var err error
+
+	switch format {
+	case "json":
+		data, err = json.MarshalIndent(metadata, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata to JSON: %w", err)
+		}
+	case "xml":
+		data, err = xml.MarshalIndent(metadata, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata to XML: %w", err)
+		}
+	case "text":
+		fallthrough
+	default:
+		data = []byte(c.formatMetadataAsText(metadata))
+	}
+
+	if output == "stdout" {
+		fmt.Print(string(data))
+	} else {
+		if err := os.WriteFile(output, data, 0644); err != nil {
+			return fmt.Errorf("failed to write output file: %w", err)
+		}
+		log.Infof("Metadata written to: %s", output)
+	}
+
+	return nil
+}
+
+// formatMetadataAsText formats the metadata as human-readable text
+func (c *ODataCmd) formatMetadataAsText(metadata *odata.Metadata) string {
+	result := "\n=== OData Service Metadata ===\n"
+	result += fmt.Sprintf("Version: %s\n", metadata.Version)
+	
+	if len(metadata.DataServices) > 0 {
+		dataService := metadata.DataServices[0]
+		result += fmt.Sprintf("Data Service Version: %s\n", dataService.Version)
+		result += fmt.Sprintf("Schema Namespace: %s\n", dataService.Schema.Namespace)
+		
+		// Print entity sets
+		entitySets := metadata.GetEntitySets()
+		if len(entitySets) > 0 {
+			result += "\n=== Entity Sets ===\n"
+			for _, es := range entitySets {
+				result += fmt.Sprintf("- %s (EntityType: %s)\n", es.Name, es.EntityType)
+			}
+		}
+		
+		// Print entity types
+		entityTypes := metadata.GetEntityTypes()
+		if len(entityTypes) > 0 {
+			result += "\n=== Entity Types ===\n"
+			for _, et := range entityTypes {
+				result += fmt.Sprintf("- %s\n", et.Name)
+				if len(et.Properties) > 0 {
+					result += "  Properties:\n"
+					for _, prop := range et.Properties {
+						nullable := ""
+						if prop.Nullable == "false" {
+							nullable = " (required)"
+						}
+						result += fmt.Sprintf("    - %s: %s%s\n", prop.Name, prop.Type, nullable)
+					}
+				}
+				if len(et.Key.PropertyRefs) > 0 {
+					result += "  Key: "
+					for i, key := range et.Key.PropertyRefs {
+						if i > 0 {
+							result += ", "
+						}
+						result += key.Name
+					}
+					result += "\n"
+				}
+			}
+		}
+	}
+	
+	return result
+}
+
+// Stop gracefully stops the OData command
+func (c *ODataCmd) Stop() error {
+	log.Infof("Stopping OData command")
+	return nil
+}

--- a/config/flags.go
+++ b/config/flags.go
@@ -27,6 +27,7 @@ type Flags struct {
 	Cmd        string
 	DiffCmd    DiffCmdFlags
 	AofCmd     AofCmdFlags
+	ODataCmd   ODataCmdFlags
 }
 
 type RdbCmdConfig struct {
@@ -86,8 +87,16 @@ type AofCmdFlags struct {
 	Size   int64
 }
 
+type ODataCmdFlags struct {
+	URL     string
+	Output  string
+	Format  string
+	Token   string
+	APIKey  string
+}
+
 func LoadFlags() error {
-	flag.StringVar(&flagVar.Cmd, "cmd", "sync", "command name : sync/rdb/diff")
+	flag.StringVar(&flagVar.Cmd, "cmd", "sync", "command name : sync/rdb/diff/aof/odata")
 	flag.StringVar(&flagVar.ConfigPath, "conf", "", "config file path")
 
 	flag.StringVar(&flagVar.DiffCmd.DiffMode, "diff.mode", "scan", "scan/rdb")
@@ -99,6 +108,12 @@ func LoadFlags() error {
 	flag.StringVar(&flagVar.AofCmd.Path, "aof.path", "", "aof path")
 	flag.Int64Var(&flagVar.AofCmd.Offset, "aof.offset", 0, "aof offset")
 	flag.Int64Var(&flagVar.AofCmd.Size, "aof.size", -1, "aof size")
+
+	flag.StringVar(&flagVar.ODataCmd.URL, "odata.url", "", "OData service URL")
+	flag.StringVar(&flagVar.ODataCmd.Output, "odata.output", "", "output file path (default: stdout)")
+	flag.StringVar(&flagVar.ODataCmd.Format, "odata.format", "text", "output format: text/json/xml")
+	flag.StringVar(&flagVar.ODataCmd.Token, "odata.token", "", "OAuth token for authentication")
+	flag.StringVar(&flagVar.ODataCmd.APIKey, "odata.apikey", "", "API key for authentication")
 
 	tmpSyncerCfg := SyncConfig{}
 	FlagsParseToStruct("sync", &tmpSyncerCfg)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ func runCmd() error {
 		cmder = cmd.NewRdbCmd()
 	case "aof":
 		cmder = cmd.NewAofCmd()
+	case "odata":
+		cmder = cmd.NewODataCmd()
 	default:
 		panicIfError(fmt.Errorf("does not support command(%s)", config.GetFlag().Cmd))
 	}

--- a/pkg/odata/metadata.go
+++ b/pkg/odata/metadata.go
@@ -1,0 +1,179 @@
+package odata
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Metadata represents the OData service metadata
+type Metadata struct {
+	XMLName xml.Name `xml:"Edmx"`
+	Version string   `xml:"Version,attr"`
+	DataServices []DataService `xml:"DataServices>DataService"`
+}
+
+// DataService represents a data service within the metadata
+type DataService struct {
+	XMLName xml.Name `xml:"DataService"`
+	Version string   `xml:"Version,attr"`
+	Schema  Schema   `xml:"Schema"`
+}
+
+// Schema represents the schema definition
+type Schema struct {
+	XMLName xml.Name `xml:"Schema"`
+	Namespace string `xml:"Namespace,attr"`
+	EntityTypes []EntityType `xml:"EntityType"`
+	EntitySets []EntitySet `xml:"EntitySet"`
+}
+
+// EntityType represents an entity type definition
+type EntityType struct {
+	XMLName xml.Name `xml:"EntityType"`
+	Name    string   `xml:"Name,attr"`
+	Key     Key      `xml:"Key"`
+	Properties []Property `xml:"Property"`
+}
+
+// EntitySet represents an entity set
+type EntitySet struct {
+	XMLName xml.Name `xml:"EntitySet"`
+	Name    string   `xml:"Name,attr"`
+	EntityType string `xml:"EntityType,attr"`
+}
+
+// Key represents the key definition for an entity
+type Key struct {
+	XMLName xml.Name `xml:"Key"`
+	PropertyRefs []PropertyRef `xml:"PropertyRef"`
+}
+
+// PropertyRef represents a property reference in a key
+type PropertyRef struct {
+	XMLName xml.Name `xml:"PropertyRef"`
+	Name    string   `xml:"Name,attr"`
+}
+
+// Property represents a property definition
+type Property struct {
+	XMLName xml.Name `xml:"Property"`
+	Name    string   `xml:"Name,attr"`
+	Type    string   `xml:"Type,attr"`
+	Nullable string  `xml:"Nullable,attr"`
+}
+
+// Client represents an OData metadata client
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	Headers    map[string]string
+}
+
+// NewClient creates a new OData metadata client
+func NewClient(baseURL string) *Client {
+	return &Client{
+		BaseURL: baseURL,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				// Follow redirects
+				return nil
+			},
+		},
+		Headers: make(map[string]string),
+	}
+}
+
+// SetHeader sets a custom header for requests
+func (c *Client) SetHeader(key, value string) {
+	c.Headers[key] = value
+}
+
+// SetAuthToken sets an authorization token
+func (c *Client) SetAuthToken(token string) {
+	c.SetHeader("Authorization", "Bearer "+token)
+}
+
+// SetAPIKey sets an API key header
+func (c *Client) SetAPIKey(apiKey string) {
+	c.SetHeader("X-API-Key", apiKey)
+}
+
+// FetchMetadata retrieves the OData service metadata
+func (c *Client) FetchMetadata() (*Metadata, error) {
+	metadataURL := c.BaseURL + "/$metadata"
+	
+	req, err := http.NewRequest("GET", metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	// Add custom headers
+	for key, value := range c.Headers {
+		req.Header.Set(key, value)
+	}
+	
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metadata request failed with status: %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Preprocess the XML to handle namespace issues
+	bodyStr := string(body)
+	// Replace edmx: prefixes with empty strings for easier parsing
+	bodyStr = strings.ReplaceAll(bodyStr, "edmx:", "")
+	bodyStr = strings.ReplaceAll(bodyStr, "xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\"", "")
+	
+	var metadata Metadata
+	if err := xml.Unmarshal([]byte(bodyStr), &metadata); err != nil {
+		// Log the first 500 characters of the response for debugging
+		if len(bodyStr) > 500 {
+			bodyStr = bodyStr[:500] + "..."
+		}
+		return nil, fmt.Errorf("failed to parse metadata XML: %w\nResponse preview: %s", err, bodyStr)
+	}
+
+	return &metadata, nil
+}
+
+// GetEntitySets returns all entity sets from the metadata
+func (m *Metadata) GetEntitySets() []EntitySet {
+	if len(m.DataServices) == 0 {
+		return nil
+	}
+	return m.DataServices[0].Schema.EntitySets
+}
+
+// GetEntityTypes returns all entity types from the metadata
+func (m *Metadata) GetEntityTypes() []EntityType {
+	if len(m.DataServices) == 0 {
+		return nil
+	}
+	return m.DataServices[0].Schema.EntityTypes
+}
+
+// FindEntityTypeByName finds an entity type by name
+func (m *Metadata) FindEntityTypeByName(name string) *EntityType {
+	entityTypes := m.GetEntityTypes()
+	for _, et := range entityTypes {
+		if et.Name == name {
+			return &et
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add OData metadata fetching functionality to the GunYu tool to allow users to inspect OData service schemas.

This PR introduces a new `odata` command that can connect to OData service endpoints, fetch their `$metadata` XML, and parse it into a structured format. It supports authentication via OAuth tokens or API keys and can output the metadata in text, JSON, or raw XML formats. The implementation includes robust XML parsing to handle various OData versions and namespace declarations.

---
<a href="https://cursor.com/background-agent?bcId=bc-a61faa19-2939-445c-a141-1d79c0839685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a61faa19-2939-445c-a141-1d79c0839685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

