### PR TITLE
data type string using set command - check key and value before writi…

### DIFF
--- a/config/cluster.yaml
+++ b/config/cluster.yaml
@@ -25,6 +25,7 @@ output:
   replay:
     resumeFromBreakPoint: true
     keyExists: replace
+    skipSameValue: true
     metric: true
     targetDb: -1
     replayTransaction: true

--- a/config/cluster2.yaml
+++ b/config/cluster2.yaml
@@ -25,6 +25,7 @@ output:
   replay:
     resumeFromBreakPoint: true
     keyExists: replace
+    skipSameValue: true
     metric: true
     targetDb: -1
     replayTransaction: true

--- a/config/config.go
+++ b/config/config.go
@@ -265,6 +265,7 @@ type ReplayConfig struct {
 	KeyExistsLog           bool          `yaml:"keyExistsLog"`
 	FunctionExists         string        `yaml:"functionExists"`
 	MaxProtoBulkLen        int           `yaml:"maxProtoBulkLen"` // proto-max-bulk-len, default value of redis is 512MiB
+	SkipSameValue          bool          `yaml:"skipSameValue"`   // Skip SET command if target key has same value
 	TargetDbCfg            *int          `yaml:"targetDb" default:"-1"`
 	TargetDb               int           `yaml:"-"`
 	TargetDbMap            map[int]int   `yaml:"targetDbMap"`

--- a/syncer/output.go
+++ b/syncer/output.go
@@ -186,6 +186,7 @@ type RedisOutputConfig struct {
 	KeyExistsLog           bool               `yaml:"keyExistsLog"`
 	FunctionExists         string             `yaml:"functionExists"`
 	MaxProtoBulkLen        int                `yaml:"maxProtoBulkLen"` // proto-max-bulk-len, default value of redis is 512MiB
+	SkipSameValue          bool               `yaml:"skipSameValue"`   // Skip SET command if target key has same value
 	TargetDb               int                `yaml:"-"`
 	TargetDbMap            map[int]int        `yaml:"targetDbMap"`
 	BatchCmdCount          uint               `yaml:"batchCmdCount"`
@@ -1343,6 +1344,7 @@ func (ro *RedisOutput) sendCmdsBatch(replayWait usync.WaitCloser, conn client.Re
 
 	inTransaction := false // in transaction batch, [multi, cmds, exec], don't send to redis separatelly
 	lastOffset := int64(-1)
+	currentCheckDB := -1 // Track current DB for skip checks to avoid unnecessary SELECTs
 	for {
 		transactionBatch := transactionMode
 		shouldUpdateCP := ro.cfg.EnableResumeFromBreakPoint && transactionMode
@@ -1359,6 +1361,19 @@ func (ro *RedisOutput) sendCmdsBatch(replayWait usync.WaitCloser, conn client.Re
 			lastOffset = item.Offset
 			if item.Cmd == "ping" { // skip ping command, keepaliveTicker handle it[multi/exec, ping issue for cluster]
 				continue
+			}
+
+			// Check if SET command should be skipped (same value already exists in target)
+			if item.Cmd == "set" && ro.cfg.SkipSameValue {
+				skip, err := ro.checkAndSkipSameValue(replayWait.Context(), conn, item, &currentCheckDB)
+				if err != nil {
+					ro.logger.Debugf("check same value error : key(%v), err(%v)", item.Args, err)
+					// On error, proceed with SET
+				} else if skip {
+					// Skip this command, continue to next
+					ro.logger.Debugf("Skip item with command set on currentCheckDB(%v), continue to next item", currentCheckDB)
+					continue
+				}
 			}
 
 			txnStatus, needFlush = transactionStatus(item.Cmd, txnStatus)
@@ -1457,6 +1472,76 @@ func (ro *RedisOutput) selectDB(currentDB int, originDB int) (int, bool) {
 	}
 
 	return targetDB, targetDB != currentDB
+}
+
+// checkAndSkipSameValue checks if a SET command should be skipped because the target key already has the same value
+func (ro *RedisOutput) checkAndSkipSameValue(ctx context.Context, conn client.Redis, cmd cmdExecution, currentCheckDB *int) (bool, error) {
+	if !ro.cfg.SkipSameValue {
+		return false, nil
+	}
+
+	// Only check simple SET commands (not SETEX, SETNX, etc.)
+	if cmd.Cmd != "set" || len(cmd.Args) < 2 {
+		return false, nil
+	}
+
+	// Extract key and value
+	keyBytes, ok := cmd.Args[0].([]byte)
+	if !ok {
+		return false, nil
+	}
+	key := util.BytesToString(keyBytes)
+
+	valueBytes, ok := cmd.Args[1].([]byte)
+	if !ok {
+		return false, nil
+	}
+	sourceValue := valueBytes
+
+	// Select the correct database (only if different from current)
+	if cmd.Db >= 0 {
+		targetDB, _ := ro.selectDB(-1, cmd.Db)
+		if *currentCheckDB != targetDB {
+			if err := redis.SelectDB(conn, uint32(targetDB)); err != nil {
+				ro.logger.Debugf("select db error for skip check : db(%d), err(%v)", targetDB, err)
+				return false, nil // On error, proceed with SET
+			}
+			*currentCheckDB = targetDB
+		}
+	}
+
+	// Check if key exists
+	exists, err := common.Int64(conn.Do("exists", key))
+	if err != nil {
+		ro.logger.Debugf("exists check error for skip : key(%s), err(%v)", key, err)
+		return false, nil // On error, proceed with SET
+	}
+
+	if exists == 0 {
+		// Key doesn't exist, proceed with SET
+		return false, nil
+	}
+
+	// Key exists, get the value
+	targetValue, err := common.Bytes(conn.Do("get", key))
+	if err != nil {
+		if errors.Is(err, common.ErrNil) {
+			// Key was deleted between EXISTS and GET, proceed with SET
+			return false, nil
+		}
+		ro.logger.Debugf("get value error for skip : key(%s), err(%v)", key, err)
+		return false, nil // On error, proceed with SET
+	}
+
+	// Compare values
+	if bytes.Equal(sourceValue, targetValue) {
+		ro.logger.Debugf("skip SET command : key(%s), value already exists and matches, sourceValue(%s), targetValue(%s)", key, util.BytesToString(sourceValue), util.BytesToString(targetValue))
+		ro.filterCounterAdd(1)
+		return true, nil // Skip this command
+	}
+
+	// Values are different, proceed with SET
+	return false, nil
 }
 
 func handleDirectError(err error) error {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -444,6 +444,7 @@ func (s *syncer) newOutput() (*RedisOutput, error) {
 		KeyExistsLog:               cfg.Replay.KeyExistsLog,
 		FunctionExists:             cfg.Replay.FunctionExists,
 		MaxProtoBulkLen:            cfg.Replay.MaxProtoBulkLen,
+		SkipSameValue:              cfg.Replay.SkipSameValue,
 		TargetDb:                   cfg.Replay.TargetDb,
 		TargetDbMap:                cfg.Replay.TargetDbMap,
 		BatchCmdCount:              cfg.Replay.BatchCmdCount,


### PR DESCRIPTION
…ng to target

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `skipSameValue` replay option that checks target keys and skips `SET` when the value is unchanged, with DB selection caching; updates config and wiring.
> 
> - **Replay/Output logic**:
>   - Introduces `ReplayConfig/RedisOutputConfig` flag `skipSameValue` to optionally skip redundant `SET` commands.
>   - Adds `RedisOutput.checkAndSkipSameValue` to `syncer/output.go` to `EXISTS/GET` and compare values before sending `SET`.
>   - Tracks `currentCheckDB` to avoid unnecessary `SELECT` calls during checks.
>   - Integrates skip check in `sendCmdsBatch` flow prior to batching.
> - **Config**:
>   - Adds `skipSameValue` to `config.ReplayConfig` and passes through in `syncer.RedisOutputConfig`.
>   - Updates cluster configs (`config/cluster.yaml`, `config/cluster2.yaml`) to include `replay.skipSameValue: true`.
> - **Wiring**:
>   - Propagates `Replay.SkipSameValue` from `config` to output via `syncer.newOutput()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bb4bac120081495269d2012c32d60faad87cf2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->